### PR TITLE
Change ConnectionConfig NodeType type to Output interface

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -29,10 +29,10 @@ func NewConnectionArgs(configMap graphql.FieldConfigArgument) graphql.FieldConfi
 }
 
 type ConnectionConfig struct {
-	Name             string          `json:"name"`
-	NodeType         *graphql.Object `json:"nodeType"`
-	EdgeFields       graphql.Fields  `json:"edgeFields"`
-	ConnectionFields graphql.Fields  `json:"connectionFields"`
+	Name             string         `json:"name"`
+	NodeType         graphql.Output `json:"nodeType"`
+	EdgeFields       graphql.Fields `json:"edgeFields"`
+	ConnectionFields graphql.Fields `json:"connectionFields"`
 }
 
 type EdgeType struct {


### PR DESCRIPTION
The existing typing requires `NodeType` be a concrete `graphql.Object`, but the spec allows for interfaces and unions as well. The more general `graphql.Output` interface should be used.