### PR TITLE
Reflect on an ID field rather than round-trip through JSON when building the GlobalID field

### DIFF
--- a/node.go
+++ b/node.go
@@ -136,7 +136,7 @@ func GlobalIDField(typeName string, idFetcher GlobalIDFetcherFn) *graphql.Field 
 				for i := 0; i < elem.NumField(); i++ {
 					f := elem.Field(i)
 					if typeOfElem.Field(i).Name == "ID" {
-						id = fmt.Sprintf("%d", f.Interface())
+						id = fmt.Sprintf("%v", f.Interface())
 						break
 					}
 				}

--- a/node.go
+++ b/node.go
@@ -137,10 +137,13 @@ func GlobalIDField(typeName string, idFetcher GlobalIDFetcherFn) *graphql.Field 
 					tf := typeOfElem.Field(i)
 					if tf.Tag.Get("json") == "id" {
 						id = fmt.Sprintf("%v", ef.Interface())
+						// We prefer the tagged field, so exit the loop
 						break
 					}
 					if tf.Name == "ID" {
 						id = fmt.Sprintf("%v", ef.Interface())
+						// We prefer the tagged field, so fall through
+						// in case a subsequent field is tagged
 					}
 				}
 			}

--- a/node.go
+++ b/node.go
@@ -130,14 +130,17 @@ func GlobalIDField(typeName string, idFetcher GlobalIDFetcherFn) *graphql.Field 
 				// try to get an ID string from p.Source
 				// via reflection on the ID field of the
 				// underlying concrete type
-
 				elem := reflect.ValueOf(p.Source).Elem()
 				typeOfElem := elem.Type()
 				for i := 0; i < elem.NumField(); i++ {
-					f := elem.Field(i)
-					if typeOfElem.Field(i).Name == "ID" {
-						id = fmt.Sprintf("%v", f.Interface())
+					ef := elem.Field(i)
+					tf := typeOfElem.Field(i)
+					if tf.Tag.Get("json") == "id" {
+						id = fmt.Sprintf("%v", ef.Interface())
 						break
+					}
+					if tf.Name == "ID" {
+						id = fmt.Sprintf("%v", ef.Interface())
 					}
 				}
 			}


### PR DESCRIPTION
When the numeric ID of a record type exceeds a certain value, generating `GlobalID` strings begins to fail. The current implementation uses a round-trip through JSON representation to pull out an `id` field, which, perhaps combined with Go's value-printing logic, causes the string representation of the ID to be in scientific notation. This later on horks up parsing of the GlobalID.

The patch here bypasses the JSON round-trip and uses the `reflect` package to read the value of the underlying struct's `ID` field directly.